### PR TITLE
fix(node-red): resolve port 443 permission denied error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,6 @@ x-node-red-security: &node-red-security
     net.ipv4.ip_unprivileged_port_start: 443
 
 
-
 services:
   # caddy:
   # image: ghcr.io/busybeaver/homelab-packages/caddy:2023-04-08@sha256:eb37103fa2d68c2335089933fbebffdbaf56bbfb949a2abb93c37c47fbb0cf7d
@@ -209,14 +208,14 @@ services:
   # - GENERIC_TIMEZONE=${TIMEZONE}
   # - TZ=${TIMEZONE}
   # - DB_TYPE=sqlite
-#       - N8N_PORT=${N8N_PORT}
-#       - N8N_DIAGNOSTICS_ENABLED=false
-#       #- N8N_BASIC_AUTH_USER_FILE=
-#       #- N8N_BASIC_AUTH_PASSWORD_FILE=
-#       #- N8N_BASIC_AUTH_HASH=true
-#       # - N8N_EDITOR_BASE_URL=${N8N_URL}
-#       # - WEBHOOK_URL=${N8N_URL}
-#     restart: always
+  #       - N8N_PORT=${N8N_PORT}
+  #       - N8N_DIAGNOSTICS_ENABLED=false
+  #       #- N8N_BASIC_AUTH_USER_FILE=
+  #       #- N8N_BASIC_AUTH_PASSWORD_FILE=
+  #       #- N8N_BASIC_AUTH_HASH=true
+  #       # - N8N_EDITOR_BASE_URL=${N8N_URL}
+  #       # - WEBHOOK_URL=${N8N_URL}
+  #     restart: always
 
 networks:
   dockervlan:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,29 @@
-x-hardened-security: &hardened-security
+x-adguard-security: &adguard-security
   cap_drop:
     - ALL
   read_only: true
   security_opt:
     - no-new-privileges:true
+
+x-uptime-kuma-security: &uptime-kuma-security
+  cap_drop:
+    - ALL
+  read_only: true
+  security_opt:
+    - no-new-privileges:true
+  sysctls:
+    net.ipv4.ip_unprivileged_port_start: 443
+
+x-node-red-security: &node-red-security
+  cap_drop:
+    - ALL
+  read_only: true
+  security_opt:
+    - no-new-privileges:true
+  sysctls:
+    net.ipv4.ip_unprivileged_port_start: 443
+
+
 
 services:
   # caddy:
@@ -45,7 +65,7 @@ services:
     mac_address: "${ADGUARD_MAC_ADDRESS}"
     dns: "${DNS_IP}"
     user: "${ADGUARD_USER}:${DOCKER_USER_GROUP}"
-    <<: *hardened-security
+    <<: *adguard-security
     cap_add:
       - NET_BIND_SERVICE
     tmpfs:
@@ -110,7 +130,7 @@ services:
     mac_address: "${UPTIME_KUMA_MAC_ADDRESS}"
     dns: "${DNS_IP}"
     user: "${UPTIME_KUMA_USER}:${DOCKER_USER_GROUP}"
-    <<: *hardened-security
+    <<: *uptime-kuma-security
     cap_add:
       - NET_BIND_SERVICE
       # health checks such as pings
@@ -140,7 +160,7 @@ services:
     # expose:
     #   - "${NODE_RED_PORT}"
     dns: "${DNS_IP}"
-    <<: *hardened-security
+    <<: *node-red-security
     cap_add:
       - NET_BIND_SERVICE
       # to communicate with all the IOT devices


### PR DESCRIPTION
This PR fixes the `listen EACCES: permission denied 0.0.0.0:443` error in Node-RED and Uptime Kuma that occurred after PR #160.

The issue was caused by the combination of `no-new-privileges: true` and the file capabilities (`setcap`) on the `node` binaries in those images. The `no_new_privs` flag prevents a process from gaining any new privileges during `execve`, including those granted via file capabilities.

The fix implements `sysctls: net.ipv4.ip_unprivileged_port_start: 443` for these services, which allows them to bind to port 443 without needing special capabilities.

Key changes:
- Added `sysctls` to `node-red` and `uptime-kuma`.
- Refactored YAML anchors to be service-specific and more descriptive (`x-adguard-security`, `x-node-red-security`, `x-uptime-kuma-security`).
- Preserved all existing comments and structure.

---
*PR created automatically by Jules for task [9142296991310723215](https://jules.google.com/task/9142296991310723215) started by @busybeaver*